### PR TITLE
Update for new powerbox flow. Simplify build.

### DIFF
--- a/.sandstorm/Vagrantfile
+++ b/.sandstorm/Vagrantfile
@@ -11,7 +11,7 @@ VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # We base ourselves off Debian Jessie
-  config.vm.box = "debian/jessie64"
+  config.vm.box = "sandstorm/debian-jessie64"
 
   if Vagrant.has_plugin?("vagrant-vbguest") then
     # vagrant-vbguest is a Vagrant plugin that upgrades
@@ -82,7 +82,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     override.vm.synced_folder "..", "/opt/app"
     override.vm.synced_folder ENV["HOME"] + "/.sandstorm", "/host-dot-sandstorm"
-    override.vm.synced_folder "..", "/vagrant"
+    override.vm.synced_folder "..", "/vagrant", disabled: true
   end
   config.vm.provider :libvirt do |libvirt, override|
     libvirt.cpus = cpus
@@ -91,6 +91,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     override.vm.synced_folder "..", "/opt/app", type: "9p", accessmode: "passthrough"
     override.vm.synced_folder ENV["HOME"] + "/.sandstorm", "/host-dot-sandstorm", type: "9p", accessmode: "passthrough"
-    override.vm.synced_folder "..", "/vagrant", type: "9p", accessmode: "passthrough"
+    override.vm.synced_folder "..", "/vagrant", type: "9p", accessmode: "passthrough", disabled: true
   end
 end

--- a/.sandstorm/global-setup.sh
+++ b/.sandstorm/global-setup.sh
@@ -32,3 +32,5 @@ GATEWAY_IP=$(ip route  | grep ^default  | cut -d ' ' -f 3)
 if nc -z "$GATEWAY_IP" 3142 ; then
     echo "Acquire::http::Proxy \"http://$GATEWAY_IP:3142\";" > /etc/apt/apt.conf.d/80httpproxy
 fi
+# Configure apt to retry fetching things that fail to download.
+echo "APT::Acquire::Retries \"10\";" > /etc/apt/apt.conf.d/80sandstorm-retry

--- a/.sandstorm/index.html
+++ b/.sandstorm/index.html
@@ -4,10 +4,12 @@
   </head>
   <body>
     <button id="request">Request</button>
+    <button id="request-save-restore">Request (with save and restore)</button>
+    <button id="request-failing-requirements">Request (with failing requirements)</button>
     <button id="offer">Offer</button>
     <div id="results"></div>
     <script type='text/javascript'>
-    document.getElementById("request").addEventListener("click", function () {
+    function doRequest(path) {
       var rpcId = Math.random();
       window.parent.postMessage({powerboxRequest: {rpcId: rpcId}}, "*");
       window.addEventListener("message", function (event) {
@@ -17,7 +19,7 @@
               return;
             }
             var xhr = new XMLHttpRequest();
-            xhr.open("PUT", "/", true);
+            xhr.open("PUT", path, true);
 
             // Hack to pass bytes through unprocessed.
             xhr.overrideMimeType("text/plain; charset=x-user-defined");
@@ -33,6 +35,15 @@
             xhr.send(event.data.token);
          }
        }, false);
+    }
+    document.getElementById("request").addEventListener("click", function () {
+      doRequest("/claim");
+    });
+    document.getElementById("request-save-restore").addEventListener("click", function () {
+      doRequest("/claim-and-save");
+    });
+    document.getElementById("request-failing-requirements").addEventListener("click", function () {
+      doRequest("/claim-failing-requirements");
     });
     document.getElementById("offer").addEventListener("click", function () {
       var xhr = new XMLHttpRequest();

--- a/.sandstorm/sandstorm-files.list
+++ b/.sandstorm/sandstorm-files.list
@@ -18,3 +18,7 @@ proc/cpuinfo
 sandstorm-manifest
 usr/lib/x86_64-linux-gnu/libstdc++.so.6
 usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.20
+usr/local/lib/libcapnp-0.6-dev.so
+usr/local/lib/libcapnp-rpc-0.6-dev.so
+usr/local/lib/libkj-0.6-dev.so
+usr/local/lib/libkj-async-0.6-dev.so

--- a/.sandstorm/setup.sh
+++ b/.sandstorm/setup.sh
@@ -22,5 +22,6 @@ set -euo pipefail
 # By default, this script does nothing.  You'll have to modify it as
 # appropriate for your application.
 export DEBIAN_FRONTEND=noninteractive
-apt-get install -y build-essential strace clang git
+apt-get update
+apt-get install -y build-essential strace clang git autoconf libtool
 exit 0

--- a/src/server.c++
+++ b/src/server.c++
@@ -151,7 +151,7 @@ public:
     auto params = context.getParams();
     auto path = params.getPath();
     auto data = params.getContent().getContent();
-    auto req = api.claimRequestRequest();
+    auto req = sessionContext.claimRequestRequest();
     auto requestToken = req.initRequestToken(data.size());
     memcpy(requestToken.begin(), data.begin(), data.size());
     if (path == "claim") {


### PR DESCRIPTION
This pull request contains that changes that I needed to make to get the integration tests to pass in https://github.com/sandstorm-io/sandstorm/pull/2027. It should not be merged until that pull request lands.

This consolidates the functionality of the powerbox-permissions and the powerbox-save branches into the powerbox branch. Now the app has three "request" buttons: the first claims the request token and calls `foo()` on the resulting cap. The second button claims the request token, saves then restores the resulting cap, then calls `foo()` on the restored cap. The third button tries to claim the token while specifying some unfulfilled `requiredPermissions`.

I adjusted the build so that pulling in ekam and all of Sandstorm is no longer necessary.
